### PR TITLE
Docs: Workflow essentials: Fix a brain typo.

### DIFF
--- a/docs/docs/04-workflow-essentials.md
+++ b/docs/docs/04-workflow-essentials.md
@@ -68,7 +68,7 @@ We save it to `echo/service.yml` file and reference it in the [overnode.yml](ove
 
 ```yml
 echo:
-    echo.yml: *
+    echo/service.yml: *
 ```
 
 Where:


### PR DESCRIPTION
I haven't tried overnode, reading the docs before starting.

I think it was meant to be `echo/service.yml` (as mentioned everywhere elsewhere) instead of `echo.yml`.